### PR TITLE
Relative dependency paths

### DIFF
--- a/Mod Source/Parallax/Parallax.csproj
+++ b/Mod Source/Parallax/Parallax.csproj
@@ -32,93 +32,93 @@
       </ItemGroup>
     <ItemGroup>
       <Reference Include="0Harmony">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_Harmony\0Harmony.dll</HintPath>
+        <HintPath>$(GameDataPath)000_Harmony\0Harmony.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Assembly-CSharp">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Assembly-CSharp-firstpass">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Kopernicus">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\Kopernicus\Plugins\Kopernicus.dll</HintPath>
+        <HintPath>$(GameDataPath)Kopernicus\Plugins\Kopernicus.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Kopernicus.Parser">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\Kopernicus\Plugins\Kopernicus.Parser.dll</HintPath>
+        <HintPath>$(GameDataPath)Kopernicus\Plugins\Kopernicus.Parser.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="KSPBurst">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\KSPBurst.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\KSPBurst.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Microsoft.Extensions.FileSystemGlobbing">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="System.IO.Compression" />
       <Reference Include="System.Runtime" />
       <Reference Include="System.Runtime.CompilerServices.Unsafe">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Unity.Burst">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\Unity.Burst.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Unity.Burst.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Unity.Burst.Unsafe">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\Unity.Burst.Unsafe.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Unity.Burst.Unsafe.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Unity.Collections">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\Unity.Collections.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Unity.Collections.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Unity.Jobs">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\Unity.Jobs.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Unity.Jobs.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="Unity.Mathematics">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\GameData\000_KSPBurst\Plugins\Unity.Mathematics.dll</HintPath>
+        <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Unity.Mathematics.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.AnimationModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.AssetBundleModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.CoreModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.ImageConversionModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.IMGUIModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.InputLegacyModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.PhysicsModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
       <Reference Include="UnityEngine.TextRenderingModule">
-        <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+        <HintPath>$(GameDataPath)..\KSP_x64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
         <Private>false</Private>
       </Reference>
 


### PR DESCRIPTION
- Made paths to dependencies for the plugin relative to the already existing `GameDataPath` in your `.csproj` this means any contributor will only be required to change 2 lines in the csproj to point to their desired KSP Instance. 

Feel free to reject & delete this PR if you wish, its just a small QOL tweak i'd like to see personally.