### PR TITLE
Disable Kopernicus ScaledOnDemandComponent for parallax planets

### DIFF
--- a/Mod Source/Parallax/Scaled System/ScaledManager.cs
+++ b/Mod Source/Parallax/Scaled System/ScaledManager.cs
@@ -47,6 +47,18 @@ namespace Parallax.Scaled_System
 
                 body.SetScaledMaterialParams(kspBody);
 
+                // We're already handling the scaled space textures. Leaving this active means that
+                // 1. kopernicus loads textures unnecessarily
+                // 2. there's a race condition between us and kopernicus for who sets the _MainTex
+                //    and _BumpTex properties last.
+                //
+                // This will show as the wrong texture sometimes being loaded when kopernicus OnDemand
+                // happens to run last if the configured textures are different between parallax and
+                // kopernicus.
+                var kopScaledOnDemand = kspBody.scaledBody.GetComponent<Kopernicus.OnDemand.ScaledSpaceOnDemand>();
+                if (kopScaledOnDemand != null)
+                    Destroy(kopScaledOnDemand);
+
                 // This returns a copy of the materials on the mesh
                 Material[] mats = meshRenderer.sharedMaterials;
 


### PR DESCRIPTION
With both of these enabled there is a race condition between parallax and kopernicus to set certain properties on the shader. Whichever one finishes last will set the `_MainTex` and `_BumpMap` properties on the shader. If the textures are different between kopernicus and parallax then this will mean that planets sometimes work correctly and sometimes work wrong.

This fixes the issue by destroying kopernicus' ScaledOnDemandComponent for any planet whose scaled space object is managed by parallax.