### PR TITLE
Mark KSPTextureLoader dependency as public

### DIFF
--- a/Mod Source/Parallax/Parallax.csproj
+++ b/Mod Source/Parallax/Parallax.csproj
@@ -103,6 +103,7 @@
       </Reference>
       <Reference Include="KSPTextureLoader">
         <HintPath>$(GameDataPath)KSPTextureLoader\Plugins\KSPTextureLoader.dll</HintPath>
+        <Private>false</Private>
       </Reference>
       <Reference Include="Microsoft.Extensions.FileSystemGlobbing">
         <HintPath>$(GameDataPath)000_KSPBurst\Plugins\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>


### PR DESCRIPTION
Somehow this wasn't happening before but this is pretty clearly wrong. When I try it now it copies the KSPTextureLoader and dependencies into `ParallaxContinued/Plugins`, which isn't great. This should fix the issue.