### PR TITLE
Move scatter shader initialization before BiomeMap.CompileToTexture

### DIFF
--- a/Mod Source/Parallax/Scatter System/ScatterManager.cs
+++ b/Mod Source/Parallax/Scatter System/ScatterManager.cs
@@ -63,11 +63,16 @@ namespace Parallax
 
             if (ConfigLoader.parallaxScatterBodies.ContainsKey(bodyName))
             {
-                currentBiomeMap = FlightGlobals.GetBodyByName(bodyName).BiomeMap.CompileToTexture();
+                // Make sure to do this before calling CompileToTexture because otherwise it blocks
+                // on the graphics thread being idle. KopernicusCBAttributeMapSO.CompileToTexture
+                // creates a new texture and that can block the render thread for quite a bit when
+                // large textures are used.
                 foreach (Scatter scatter in ConfigLoader.parallaxScatterBodies[bodyName].fastScatters)
                 {
                     scatter.InitShader();
                 }
+
+                currentBiomeMap = FlightGlobals.GetBodyByName(bodyName).BiomeMap.CompileToTexture();
 
                 foreach (ScatterRenderer renderer in scatterRenderers)
                 {


### PR DESCRIPTION
Instantiating a shader needs to sync with the graphics thread, but KopernicusCBAttributeMapSO.CompileToTexture creates a new texture when called and this keeps the graphics thread busy for up to multiple seconds with larger textures.

When testing with sol the call to `UnityObject.Instantiate` goes from taking 3s down to only taking 60ms.

### Before
<img width="1710" height="722" alt="image" src="https://github.com/user-attachments/assets/7b49dd9b-b2ff-49c0-8c08-403cc35a6d50" />
<img width="1666" height="916" alt="image" src="https://github.com/user-attachments/assets/c6d69d2f-dded-4c80-a289-47166a35e285" />

### After
<img width="1692" height="852" alt="image" src="https://github.com/user-attachments/assets/e824df1e-9265-42b2-a243-8295dcd6a968" />
<img width="1431" height="923" alt="image" src="https://github.com/user-attachments/assets/5224255f-e370-4908-a22d-32100608ba03" />
