### PR TITLE
Avoid reloading textures during PQS reload

### DIFF
--- a/Mod Source/Parallax/Scatter System/ScatterManager.cs
+++ b/Mod Source/Parallax/Scatter System/ScatterManager.cs
@@ -57,7 +57,8 @@ namespace Parallax
 
             }
         }
-        void DominantBodyLoaded(string bodyName)
+        void DominantBodyLoaded(string bodyName) => DominantBodyLoaded(bodyName, isRestart: false);
+        void DominantBodyLoaded(string bodyName, bool isRestart)
         {
             ParallaxDebug.Log("[Scatter Manager] body loading " + bodyName);
 
@@ -72,7 +73,13 @@ namespace Parallax
                     scatter.InitShader();
                 }
 
-                currentBiomeMap = FlightGlobals.GetBodyByName(bodyName).BiomeMap.CompileToTexture();
+                if (!isRestart)
+                {
+                    if (currentBiomeMap != null)
+                        UnityEngine.Object.Destroy(currentBiomeMap);
+
+                    currentBiomeMap = FlightGlobals.GetBodyByName(bodyName).BiomeMap.CompileToTexture();
+                }
 
                 foreach (ScatterRenderer renderer in scatterRenderers)
                 {
@@ -86,7 +93,9 @@ namespace Parallax
                 }
             }
         }
-        void DominantBodyUnloaded(string bodyName)
+
+        void DominantBodyUnloaded(string bodyName) => DominantBodyUnloaded(bodyName, isRestart: false);
+        void DominantBodyUnloaded(string bodyName, bool isRestart)
         {
             if (ConfigLoader.parallaxScatterBodies.ContainsKey(bodyName))
             {
@@ -102,14 +111,18 @@ namespace Parallax
                 }
 
                 ParallaxScatterBody body = ConfigLoader.parallaxScatterBodies[bodyName];
-                body.UnloadTextures();
-                UnityEngine.Object.Destroy(currentBiomeMap);
+
+                if (!isRestart)
+                {
+                    body.UnloadTextures();
+                    UnityEngine.Object.Destroy(currentBiomeMap);
+                }
             }
         }
         void DominantBodyRestarted(string bodyName)
         {
-            DominantBodyUnloaded(bodyName);
-            DominantBodyLoaded(bodyName);
+            DominantBodyUnloaded(bodyName, isRestart: true);
+            DominantBodyLoaded(bodyName, isRestart: true);
         }
         // After any world origin shifts
         // Rendering is kicked off from here

--- a/Mod Source/Parallax/Scatter System/ScatterManager.cs
+++ b/Mod Source/Parallax/Scatter System/ScatterManager.cs
@@ -63,11 +63,16 @@ namespace Parallax
 
             if (ConfigLoader.parallaxScatterBodies.ContainsKey(bodyName))
             {
-                currentBiomeMap = FlightGlobals.GetBodyByName(bodyName).BiomeMap.CompileToTexture();
+                // Make sure to do this before calling CompileToTexture because otherwise it blocks
+                // on the graphics thread being idle. KopernicusCBAttributeMapSO.CompileToTexture
+                // creates a new texture and that can block the render thread for quite a bit when
+                // large textures are used.
                 foreach (Scatter scatter in ConfigLoader.parallaxScatterBodies[bodyName].fastScatters)
                 {
                     scatter.InitShader();
                 }
+
+                currentBiomeMap = FlightGlobals.GetBodyByName(bodyName).BiomeMap.CompileToTexture();
 
                 foreach (ScatterRenderer renderer in scatterRenderers)
                 {


### PR DESCRIPTION
Draft because this depends on #93 

Reloading textures and constructing the biome map is by far the most expensive part of a scene switch for parallax. Not to mention it happens _twice_. These won't change across a PQS restart so it is safe to just keep them around.

This patch results in a ~2.5s improvement to scene switch times with Sol.

### Before
<img width="1692" height="852" alt="image" src="https://github.com/user-attachments/assets/444f631d-3d1a-4b1d-ba66-c8d47dfedb17" />
<img width="1431" height="923" alt="image" src="https://github.com/user-attachments/assets/7edacbab-3917-4bd8-b021-ac97dc3934c9" />

### After
<img width="1703" height="895" alt="image" src="https://github.com/user-attachments/assets/f1780841-36b0-4c85-8613-05bd1e62b359" />
<img width="1709" height="923" alt="image" src="https://github.com/user-attachments/assets/3c884576-2670-4d8a-a3a1-68fc8ec7f38b" />

