### PR TITLE
Add names to all created ComputeBuffers

### DIFF
--- a/Mod Source/Parallax/PQS Mods/ScatterData.cs
+++ b/Mod Source/Parallax/PQS Mods/ScatterData.cs
@@ -101,7 +101,10 @@ namespace Parallax
             distributeKernel = GetDistributeKernel();
             evaluateKernel = GetEvaluateKernel();
 
-            outputScatterDataBuffer = new ComputeBuffer(outputSize, PositionData.Size(), ComputeBufferType.Append);
+            outputScatterDataBuffer = new ComputeBuffer(outputSize, PositionData.Size(), ComputeBufferType.Append)
+            {
+                name = $"parallax:{parent.quad.sphereRoot.name}/quad/{parent.quad.name}/scatter-output"
+            };
             scatterShader.SetBuffer(distributeKernel, ParallaxScatterShaderProperties.transformsBufferID, outputScatterDataBuffer);
             scatterShader.SetBuffer(evaluateKernel, ParallaxScatterShaderProperties.positionsBufferID, outputScatterDataBuffer);
 
@@ -255,7 +258,10 @@ namespace Parallax
         public void ComputeDispatchArgs()
         {
             // Stores the count of the generated positions
-            objectLimits = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments);
+            objectLimits = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments)
+            {
+                name = $"parallax:{parent.quad.sphereRoot.name}/quad/{parent.quad.name}/object-limits"
+            };
             objectLimits.SetData(indirectArgs);
 
             // Read count from AppendStructuredBuffer to the objectlimits, used in the early return check from evaluate - can't process more data than exists
@@ -303,7 +309,10 @@ namespace Parallax
             count[1] = 1;
             count[2] = 1;
 
-            dispatchArgs = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments);
+            dispatchArgs = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments)
+            {
+                name = $"parallax:{parent.quad.sphereRoot.name}/quad/{parent.quad.name}/dispatch-args"
+            };
             dispatchArgs.SetData(count);
 
             // This function may never execute because the quad tries to cleanup before the readback is complete
@@ -352,7 +361,10 @@ namespace Parallax
             count[1] = 1;
             count[2] = 1;
 
-            dispatchArgs = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments);
+            dispatchArgs = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments)
+            {
+                name = $"parallax:{parent.quad.sphereRoot.name}/quad/{parent.quad.name}/dispatch-args"
+            };
             dispatchArgs.SetData(count);
 
             // This function may never execute because the quad tries to cleanup before the readback is complete

--- a/Mod Source/Parallax/PQS Mods/ScatterSystemQuadData.cs
+++ b/Mod Source/Parallax/PQS Mods/ScatterSystemQuadData.cs
@@ -103,6 +103,13 @@ namespace Parallax
             sourceUVsBuffer = new ComputeBuffer(uvs.Length, sizeof(float) * 3, ComputeBufferType.Structured);
             sourceDirsFromCenterBuffer = new ComputeBuffer(vertices.Length, sizeof(float) * 3, ComputeBufferType.Structured);
 
+            sourceVertsBuffer.name = $"parallax:{quad.sphereRoot.name}/quad/{ID}/source-verts";
+            sourceNormalsBuffer.name = $"parallax:{quad.sphereRoot.name}/quad/{ID}/source-normals";
+            sourceTrianglesBuffer.name = $"parallax:{quad.sphereRoot.name}/quad/{ID}/source-triangles";
+            sourceColorsBuffer.name = $"parallax:{quad.sphereRoot.name}/quad/{ID}/source-colors";
+            sourceUVsBuffer.name = $"parallax:{quad.sphereRoot.name}/quad/{ID}/source-uvs";
+            sourceDirsFromCenterBuffer.name = $"parallax:{quad.sphereRoot.name}/quad/{ID}/source-dirs-from-center";
+
             sourceVertsBuffer.SetData(vertices);
             sourceNormalsBuffer.SetData(normals);
             sourceTrianglesBuffer.SetData(triangles);

--- a/Mod Source/Parallax/Scatter System/ScatterManager.cs
+++ b/Mod Source/Parallax/Scatter System/ScatterManager.cs
@@ -50,6 +50,7 @@ namespace Parallax
                     ScatterRenderer renderer = perPlanetRenderer.AddComponent<ScatterRenderer>();
                     renderer.planetName = body.Key;
                     renderer.scatter = scatter.Value;
+                    renderer.name = scatter.Key;
                     scatterRenderers.Add(renderer);
                     fastScatterRenderers.Add(scatter.Key, renderer);
                     scatter.Value.renderer = renderer;

--- a/Mod Source/Parallax/Scatter System/ScatterRenderer.cs
+++ b/Mod Source/Parallax/Scatter System/ScatterRenderer.cs
@@ -272,6 +272,10 @@ namespace Parallax
                 outputLOD0 = new ComputeBuffer(newLOD0Count, TransformData.Size(), ComputeBufferType.Append);
                 outputLOD1 = new ComputeBuffer(newLOD1Count, TransformData.Size(), ComputeBufferType.Append);
                 outputLOD2 = new ComputeBuffer(newLOD2Count, TransformData.Size(), ComputeBufferType.Append);
+
+                outputLOD0.name = $"parallax:{planetName}/scatter/{name}/outputLOD0";
+                outputLOD1.name = $"parallax:{planetName}/scatter/{name}/outputLOD1";
+                outputLOD2.name = $"parallax:{planetName}/scatter/{name}/outputLOD2";
             }
             else
             {
@@ -334,6 +338,10 @@ namespace Parallax
 
             indirectArgsLOD2 = new ComputeBuffer(1, argumentsLod2.Length * sizeof(uint), ComputeBufferType.IndirectArguments);
             indirectArgsLOD2.SetData(argumentsLod2);
+
+            indirectArgsLOD0.name = $"parallax:{planetName}/scatter/{name}/indirectArgsLOD0";
+            indirectArgsLOD1.name = $"parallax:{planetName}/scatter/{name}/indirectArgsLOD1";
+            indirectArgsLOD2.name = $"parallax:{planetName}/scatter/{name}/indirectArgsLOD2";
         }
         // Called on Update from ScatterManager.cs
         public void PreRender()
@@ -386,6 +394,10 @@ namespace Parallax
             ComputeBuffer countBuffer0 = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments);
             ComputeBuffer countBuffer1 = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments);
             ComputeBuffer countBuffer2 = new ComputeBuffer(3, sizeof(int), ComputeBufferType.IndirectArguments);
+
+            countBuffer0.name = $"parallax:{planetName}/scatter/{name}/countBuffer0";
+            countBuffer1.name = $"parallax:{planetName}/scatter/{name}/countBuffer1";
+            countBuffer2.name = $"parallax:{planetName}/scatter/{name}/countBuffer2";
 
             int[] countLOD0 = { 0, 0, 0 };
             int[] countLOD1 = { 0, 0, 0 };


### PR DESCRIPTION
No other behaviour changes here, but this should help people debugging memory usage through the renderdoc or nsight graphics figure out what buffer is what.