### PR TITLE
Actually destroy ScaledOnDemandComponent

### DIFF
--- a/Mod Source/Parallax/Scaled System/ScaledManager.cs
+++ b/Mod Source/Parallax/Scaled System/ScaledManager.cs
@@ -204,7 +204,7 @@ namespace Parallax.Scaled_System
                 CelestialBody kspBody = FlightGlobals.GetBodyByName(body.planetName);
 
                 // Body loaded OnDisable for this component
-                Destroy(kspBody.GetComponent<ScaledOnDemandComponent>());
+                Destroy(kspBody.scaledBody.GetComponent<ScaledOnDemandComponent>());
             }
         }
     }


### PR DESCRIPTION
This gets created on the scaledBody, but OnDisable was attempting to get one from the kspBody and destroy that. This did nothing because GetComponent would always return null, so ScaledOnDemandComponents keep getting added to each planet and end up stacking up with each scene switch.

I think the end result is actually mostly harmless, but it does mean that there is extra logspam with each scene switch and I'm not really sure what problems having a bunch of `ScaledOnDemandComponent`s running will cause.