### PR TITLE
Fix dangling ScaledManager.Instance causing crash on scene change (Space Center)

### DIFF
--- a/Mod Source/Parallax/Scaled System/ScaledManager.cs
+++ b/Mod Source/Parallax/Scaled System/ScaledManager.cs
@@ -30,8 +30,21 @@ namespace Parallax.Scaled_System
             {
                 ParallaxDebug.Log("Scaled manager destroyed - not in the right scene");
                 Destroy(this);
+                // Don't assign Instance below: this component is being destroyed.
+                // Callers rely on Instance being null in scenes without a ScaledManager
+                // (e.g. the Space Center); see ParallaxScaledBody.LoadAsync.
+                return;
             }
             Instance = this;
+        }
+        public void OnDestroy()
+        {
+            // Avoid leaving Instance pointing at a destroyed component, which would
+            // pass the `Instance == null` guards but fault on use (e.g. StartCoroutine).
+            if (Instance == this)
+            {
+                Instance = null;
+            }
         }
         public void Start()
         {


### PR DESCRIPTION
## Summary

Fixes a recurring **access-violation crash that occurs when transitioning through the Space Center** (e.g. Flight → Space Center → SPH), where Parallax is mid-load of a scaled body. This is the crash described in #120.

## Root cause

`ScaledManager.Awake()` destroys itself in scenes that shouldn't have a manager, but then assigns `Instance` anyway:

```csharp
if (!Flight && !TrackStation && !MainMenu)
{
    Destroy(this);          // e.g. SPACECENTER / editor
}
Instance = this;            // <-- still runs: Instance now points at a destroyed component
```

`Destroy(this)` is deferred to end-of-frame, and there is no `OnDestroy` to clear `Instance`, so `Instance` becomes a **dangling reference to a destroyed `MonoBehaviour`**. Unity's overloaded `== null` only reports the object as null once destruction has finalized, so within the transition window the guard in `ParallaxScaledBody.LoadAsync()` is defeated:

```csharp
if (ScaledManager.Instance == null)        // returns false for the not-yet-finalized destroyed object
    deferredTerrainBodyLoad = true;
else
    terrainBodyLoad = ScaledManager.Instance.StartCoroutine(terrainBody.LoadAsync());  // faults here
```

`StartCoroutine` then runs on the freed object → `NullReferenceException` in `(wrapper managed-to-native) UnityEngine.MonoBehaviour.IsObjectMonoBehaviour` → native `0xC0000005`. The `LoadAsync` guard and its own comment ("When switching to KSC there is no ScaledManager") already assume `Instance` is null in these scenes — the `Awake` bug breaks that assumption.

## Fix

1. `return;` after `Destroy(this)` so `Instance` is **not** reassigned to the destroyed component (restores the null-in-KSC assumption `LoadAsync` relies on).
2. Add `OnDestroy()` that nulls `Instance` when it is this manager, so teardown is robust regardless of scene-unload destruction ordering (not just relying on Unity's fake-null timing).

## Regression considerations

- Valid scenes (Flight/TrackStation/MainMenu) are unchanged — `Instance = this` still runs.
- In other scenes `Instance` becomes properly `null`, which is the state `LoadAsync` already documents and handles via its deferred path.
- `OnDestroy` only clears `Instance` when it equals this instance, so it cannot clobber a newer manager.

## Testing status — DRAFT

Opening as a **draft** for maintainer review of the approach. I have **not** yet been able to compile against KSP 1.12.x or run an in-game repro in my environment. Before this is ready to merge it should be:
- built against the mod's normal target, and
- validated by repeatedly entering/leaving the Space Center with Parallax active (crash gone), confirming scaled textures still load normally in flight.

Happy to adjust naming/style/placement to match project conventions. cc the #120 reporter for repro validation if useful.
