### PR TITLE
Fix linux crash when collider data is removed twice (issue #54)

### DIFF
--- a/Mod Source/Parallax/Collision System/CollisionManager.cs
+++ b/Mod Source/Parallax/Collision System/CollisionManager.cs
@@ -28,6 +28,9 @@ namespace Parallax
         // Pointer to Scatter in collideableScatters
         public int collideableScattersIndex;
         public int dataCount;
+
+        // Set once the native arrays have been freed, so we never free them twice
+        public bool disposed = false;
         public ScatterColliderData(ScatterSystemQuadData scatterSystemQuad, NativeArray<PositionData> quadLocalData, int collideableScattersIndex)
         {
             this.scatterSystemQuad = scatterSystemQuad;
@@ -46,6 +49,26 @@ namespace Parallax
                 initializeTo = float.MaxValue
             };
             initDistancesHandle = initJob.Schedule(dataCount, dataCount / 8);
+        }
+        // Frees the native arrays. Safe to call more than once
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+            disposed = true;
+
+            // The init job writes lastDistances, so let it finish before we free it
+            initDistancesHandle.Complete();
+            if (lastDistances.IsCreated)
+            {
+                lastDistances.Dispose();
+            }
+            if (quadLocalData.IsCreated)
+            {
+                quadLocalData.Dispose();
+            }
         }
     }
     /// <summary>
@@ -178,6 +201,12 @@ namespace Parallax
         {
             foreach (ScatterColliderData data in incomingData)
             {
+                // Skip data that was already removed and disposed this frame
+                if (data.disposed)
+                {
+                    continue;
+                }
+
                 // Complete the distance initialisation here
                 data.initDistancesHandle.Complete();
                 collisionData.Add(data);
@@ -185,7 +214,7 @@ namespace Parallax
                 // Add job info
                 sqrQuadBounds.Add(data.scatterSystemQuad.sqrQuadWidth);
             }
-            
+
             incomingData.Clear();
         }
         // Remove data from processing
@@ -193,13 +222,21 @@ namespace Parallax
         {
             foreach (ScatterColliderData data in outgoingData)
             {
-                // Mirror the removal from fastlist in our own data here
-                // Remove job info
-                sqrQuadBounds.RemoveAtSwapBack(data.id);
-                collisionData.Remove(data);
+                // Don't remove the same data twice
+                if (data.disposed)
+                {
+                    continue;
+                }
 
-                data.lastDistances.Dispose();
-                data.quadLocalData.Dispose();
+                // Capture the id before the swap-back changes it. Only remove from
+                // sqrQuadBounds if the item was actually in collisionData, so the two stay aligned
+                int id = data.id;
+                if (collisionData.Remove(data) && id >= 0 && id < sqrQuadBounds.Length)
+                {
+                    sqrQuadBounds.RemoveAtSwapBack(id);
+                }
+
+                data.Dispose();
             }
             outgoingData.Clear();
         }
@@ -514,15 +551,25 @@ namespace Parallax
                 CompleteColliderJob();
             }
 
-            // Complete the init distances job in the very rare case it has not completed yet
+            // Dispose anything still active or queued and reset the lists, otherwise a body
+            // reload leaks the native arrays and leaves stale data behind
+            foreach (ScatterColliderData data in collisionData)
+            {
+                data.Dispose();
+            }
             foreach (ScatterColliderData data in incomingData)
             {
-                data.initDistancesHandle.Complete();
-                if (data.lastDistances.IsCreated)
-                {
-                    data.lastDistances.Dispose();
-                }
+                data.Dispose();
             }
+            foreach (ScatterColliderData data in outgoingData)
+            {
+                data.Dispose();
+            }
+
+            collisionData.Clear();
+            incomingData.Clear();
+            outgoingData.Clear();
+            sqrQuadBounds.Clear();
 
             for (int i = 0; i < numCollideableScatters; i++)
             {

--- a/Mod Source/Parallax/PQS Mods/ScatterData.cs
+++ b/Mod Source/Parallax/PQS Mods/ScatterData.cs
@@ -564,10 +564,11 @@ namespace Parallax
                 eventAdded = false;
             }
 
-            // Queue up collider removal
+            // Queue up collider removal, and clear the flag so a repeat Cleanup() can't queue it twice
             if (collidersAdded)
             {
                 CollisionManager.QueueOutgoingData(collisionData);
+                collidersAdded = false;
             }
 
             outputScatterDataBuffer?.Dispose();

--- a/Mod Source/Parallax/Tools/FastList.cs
+++ b/Mod Source/Parallax/Tools/FastList.cs
@@ -38,33 +38,45 @@ namespace Parallax
             item.id = list.Count;
             list.Add(item);
         }
-        public void Remove(int id)
+        public bool Remove(int id)
         {
-            // Handle edge case where there is no item to replace
-            if (list.Count == 1)
+            int count = list.Count;
+
+            // Stale or out of range id - nothing to remove
+            if (id < 0 || id >= count)
             {
-                list.RemoveAt(0);
-                return;
+                return false;
             }
 
-            // Fetch the item from the end of the list to replace the item we're removing
-            T itemToReplace = list[list.Count - 1];
+            // Handle edge case where there is no item to replace
+            if (count == 1)
+            {
+                list.Clear();
+                return true;
+            }
 
-            // Set the replacement item ID to the ID we're removing to maintain ID continuity
-            itemToReplace.id = id;
+            // Move the last item into the freed slot to keep id == index
+            T lastItem = list[count - 1];
+            lastItem.id = id;
+            list[id] = lastItem;
 
-            // Set the last list element to what we're about to remove
-            list[list.Count - 1] = list[id];
-
-            // Set the (now freed) ID to the replacement
-            list[id] = itemToReplace;
-
-            // Remove the item
-            list.RemoveAt(list.Count - 1);
+            list.RemoveAt(count - 1);
+            return true;
         }
-        public void Remove(T item)
+        public bool Remove(T item)
         {
-            Remove(item.id);
+            if (item == null || item.id < 0 || item.id >= list.Count)
+            {
+                return false;
+            }
+
+            // After a swap-back the slot may hold a different item - don't remove the wrong one
+            if (list[item.id] != item)
+            {
+                return false;
+            }
+
+            return Remove(item.id);
         }
 
         public IEnumerator GetEnumerator()


### PR DESCRIPTION
Fixes #54. Builds on #80.

This started from #80, which fixes the same crash by adding bounds checks to
`FastList`. That stops `FastList.Remove` from throwing, but it treats the
symptom: the bad removal just fails quietly, it doesn't fix *why* a bad removal
gets queued, and it doesn't cover the native double-free that causes the hard
segfault on Linux. Once I traced the root cause the fix ended up fairly
different, so I'm opening this as a separate PR rather than pushing onto #80.

### Root cause
The same `ScatterColliderData` gets queued for removal more than once.
`ScatterData.Cleanup()` queues it but never clears `collidersAdded`, so a
second `Cleanup()` (scene change, body reload) queues the same object again.
The second removal runs with a stale `id`, which indexes out of range *and*
disposes the `NativeArray`s a second time and the double free is the segfault.
Because the exception is thrown before `outgoingData.Clear()`, the bad entry
stays queued and the exception repeats every frame, which is the slowdown that
shows up alongside the crash.

### What this changes
- `ScatterData.Cleanup()` clears `collidersAdded` after queueing the removal,
  so the same data can't be queued twice (the actual root cause).
- `ScatterColliderData` gets a `Dispose()` that frees its native arrays once
  (completing the init job first), guarded by a `disposed` flag, so a double
  removal can't double-free.
- `CollisionManager` skips already-disposed data when adding/removing, only
  drops the matching `sqrQuadBounds` entry when the item was actually in
  `collisionData` (keeping the two parallel lists aligned), and disposes +
  clears everything in `Cleanup()` so a body reload doesn't leak or keep
  stale data.
- `FastList.Remove` keeps the defensive guard from #80 (ignore out-of-range
  ids, and check the slot still holds the item before removing), now returning
  whether anything was removed so the caller can keep the parallel lists in
  sync.

### Testing
Built and tested on Linux: ran the repro (craft on a Parallax body → tracking
station → switching bodies repeatedly). The exception spam and crash are gone,
and colliders still spawn and despawn correctly.
