### PR TITLE
Add optional PQS terrain fade textures for distant zoom levels

### DIFF
--- a/Assets/Shaders/Includes/BiplanarFunctions.cginc
+++ b/Assets/Shaders/Includes/BiplanarFunctions.cginc
@@ -110,6 +110,74 @@ float4 SampleBiplanarTexture(sampler2D tex, PixelBiplanarParams params, float3 w
     return (x * w.x + y * w.y) / (w.x + w.y);
 }
 
+float4 SampleBiplanarTextureWithFade(sampler2D tex, sampler2D fadeTex, PixelBiplanarParams params, float3 worldPos0, float3 worldPos1, float3 worldNormal, float blend, float floorLogDistance)
+{
+    float4 x0;
+    float4 y0;
+    float4 x1;
+    float4 y1;
+
+    if (floorLogDistance - 1 >= _FadeTextureStartLevel)
+    {
+        x0 = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL0(params.ma, params, worldPos0));
+        y0 = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL0(params.me, params, worldPos0));
+    }
+    else
+    {
+        x0 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL0(params.ma, params, worldPos0));
+        y0 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL0(params.me, params, worldPos0));
+    }
+
+    if (floorLogDistance >= _FadeTextureStartLevel)
+    {
+        x1 = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL1(params.ma, params, worldPos1));
+        y1 = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL1(params.me, params, worldPos1));
+    }
+    else
+    {
+        x1 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL1(params.ma, params, worldPos1));
+        y1 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL1(params.me, params, worldPos1));
+    }
+
+    float4 x = lerp(x0, x1, blend);
+    float4 y = lerp(y0, y1, blend);
+
+    float2 w = float2(params.absWorldNormal[params.ma.x], params.absWorldNormal[params.me.x]);
+    w = saturate(w * 2.365744f - 1.365744f);
+    w = pow(w, params.blend * 0.125f);
+
+    return (x * w.x + y * w.y) / (w.x + w.y);
+}
+
+float4 SampleBiplanarTextureWithZeroFade(sampler2D tex, PixelBiplanarParams params, float3 worldPos0, float3 worldPos1, float3 worldNormal, float blend, float floorLogDistance)
+{
+    float4 x0 = 0;
+    float4 y0 = 0;
+    float4 x1 = 0;
+    float4 y1 = 0;
+
+    if (floorLogDistance - 1 < _FadeTextureStartLevel)
+    {
+        x0 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL0(params.ma, params, worldPos0));
+        y0 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL0(params.me, params, worldPos0));
+    }
+
+    if (floorLogDistance < _FadeTextureStartLevel)
+    {
+        x1 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL1(params.ma, params, worldPos1));
+        y1 = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL1(params.me, params, worldPos1));
+    }
+
+    float4 x = lerp(x0, x1, blend);
+    float4 y = lerp(y0, y1, blend);
+
+    float2 w = float2(params.absWorldNormal[params.ma.x], params.absWorldNormal[params.me.x]);
+    w = saturate(w * 2.365744f - 1.365744f);
+    w = pow(w, params.blend * 0.125f);
+
+    return (x * w.x + y * w.y) / (w.x + w.y);
+}
+
 float4 SampleBiplanarTextureLOD(sampler2D tex, VertexBiplanarParams params, float3 worldPos0, float3 worldPos1, float3 worldNormal, float blend)
 {
     // Project and fetch
@@ -130,6 +198,35 @@ float4 SampleBiplanarTextureLOD(sampler2D tex, VertexBiplanarParams params, floa
     w = pow(w, params.blend * 0.125f);
     
     // Blend
+    return (x * w.x + y * w.y) / (w.x + w.y);
+}
+
+float4 SampleBiplanarTextureLODWithZeroFade(sampler2D tex, VertexBiplanarParams params, float3 worldPos0, float3 worldPos1, float3 worldNormal, float blend, float floorLogDistance)
+{
+    float4 x0 = 0;
+    float4 y0 = 0;
+    float4 x1 = 0;
+    float4 y1 = 0;
+
+    if (floorLogDistance - 1 < _FadeTextureStartLevel)
+    {
+        x0 = tex2Dlod(tex, TEX2D_LOD_COORDS(params.ma, worldPos0, 0));
+        y0 = tex2Dlod(tex, TEX2D_LOD_COORDS(params.me, worldPos0, 0));
+    }
+
+    if (floorLogDistance < _FadeTextureStartLevel)
+    {
+        x1 = tex2Dlod(tex, TEX2D_LOD_COORDS(params.ma, worldPos1, 0));
+        y1 = tex2Dlod(tex, TEX2D_LOD_COORDS(params.me, worldPos1, 0));
+    }
+
+    float4 x = lerp(x0, x1, blend);
+    float4 y = lerp(y0, y1, blend);
+
+    float2 w = float2(params.absWorldNormal[params.ma.x], params.absWorldNormal[params.me.x]);
+    w = saturate(w * 2.365744f - 1.365744f);
+    w = pow(w, params.blend * 0.125f);
+
     return (x * w.x + y * w.y) / (w.x + w.y);
 }
 
@@ -184,5 +281,60 @@ NORMAL_FLOAT SampleBiplanarNormal(sampler2D tex, PixelBiplanarParams params, flo
     
     NORMAL_FLOAT result = (x * w.x + y * w.y) / (w.x + w.y);
     
+    return result;
+}
+
+NORMAL_FLOAT SampleBiplanarNormalWithFade(sampler2D tex, sampler2D fadeTex, PixelBiplanarParams params, float3 worldPos0, float3 worldPos1, float3 worldNormal, float blend, float floorLogDistance)
+{
+    float4 texLevel0x;
+    float4 texLevel0y;
+    float4 texLevel1x;
+    float4 texLevel1y;
+
+    if (floorLogDistance - 1 >= _FadeTextureStartLevel)
+    {
+        texLevel0x = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL0(params.ma, params, worldPos0));
+        texLevel0y = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL0(params.me, params, worldPos0));
+    }
+    else
+    {
+        texLevel0x = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL0(params.ma, params, worldPos0));
+        texLevel0y = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL0(params.me, params, worldPos0));
+    }
+
+    if (floorLogDistance >= _FadeTextureStartLevel)
+    {
+        texLevel1x = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL1(params.ma, params, worldPos1));
+        texLevel1y = tex2Dgrad(fadeTex, TEX2D_GRAD_COORDS_LEVEL1(params.me, params, worldPos1));
+    }
+    else
+    {
+        texLevel1x = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL1(params.ma, params, worldPos1));
+        texLevel1y = tex2Dgrad(tex, TEX2D_GRAD_COORDS_LEVEL1(params.me, params, worldPos1));
+    }
+
+    NORMAL_FLOAT x0 = ParallaxUnpackNormalEmission(texLevel0x);
+    NORMAL_FLOAT y0 = ParallaxUnpackNormalEmission(texLevel0y);
+    NORMAL_FLOAT x1 = ParallaxUnpackNormalEmission(texLevel1x);
+    NORMAL_FLOAT y1 = ParallaxUnpackNormalEmission(texLevel1y);
+
+    NORMAL_FLOAT x = lerp(x0, x1, blend);
+    NORMAL_FLOAT y = lerp(y0, y1, blend);
+
+    x.xyz *= _BumpScale;
+    y.xyz *= _BumpScale;
+
+    x.xyz = normalize(float3(x.y + worldNormal[params.ma.z], x.x + worldNormal[params.ma.y], worldNormal[params.ma.x]));
+    y.xyz = normalize(float3(y.y + worldNormal[params.me.z], y.x + worldNormal[params.me.y], worldNormal[params.me.x]));
+
+    x.xyz = float3(x[params.ma.z], x[params.ma.y], x[params.ma.x]);
+    y.xyz = float3(y[params.me.z], y[params.me.y], y[params.me.x]);
+
+    float2 w = float2(params.absWorldNormal[params.ma.x], params.absWorldNormal[params.me.x]);
+    w = saturate(w * 2.365744f - 1.365744f);
+    w = pow(w, params.blend * 0.125f);
+
+    NORMAL_FLOAT result = (x * w.x + y * w.y) / (w.x + w.y);
+
     return result;
 }

--- a/Assets/Shaders/Terrain/Parallax.shader
+++ b/Assets/Shaders/Terrain/Parallax.shader
@@ -33,6 +33,12 @@ Shader "Custom/Parallax"
         _BumpMapSteep("Steep Bump Map", 2D) = "bump" {}
 
         [Space(10)]
+        [Header(Fade Textures)]
+        [Space(10)]
+        _MainTexFade("Fade Texture", 2D) = "white" {}
+        _BumpMapFade("Fade Bump Map", 2D) = "bump" {}
+
+        [Space(10)]
         _InfluenceMap("Influence Map", 2D) = "white" {}
         _DisplacementMap("Displacement Map", 2D) = "black" {}
         _OcclusionMap("Occlusion Map", 2D) = "white" {}
@@ -44,6 +50,7 @@ Shader "Custom/Parallax"
         _DisplacementScale("Displacement Scale", Range(0, 0.3)) = 0
         _DisplacementOffset("Displacement Offset", Range(-1, 1)) = 0
         _BiplanarBlendFactor("Biplanar Blend Factor", Range(0.01, 8)) = 1
+        _FadeTextureStartLevel("Fade Texture Start Level", Float) = 1
 
         [Space(10)]
         [Header(Texture Blending Parameters)]
@@ -97,6 +104,7 @@ Shader "Custom/Parallax"
             #pragma multi_compile_local _          INFLUENCE_MAPPING
             #pragma multi_compile_local _          ADVANCED_BLENDING
             #pragma multi_compile_local _          EMISSION
+            #pragma multi_compile_local _          PARALLAX_FADE_TEXTURES
             #pragma multi_compile_fog
             //#pragma skip_variants POINT_COOKIE LIGHTMAP_ON DIRLIGHTMAP_COMBINED DYNAMICLIGHTMAP_ON LIGHTMAP_SHADOW_MIXING VERTEXLIGHT_ON
 
@@ -194,7 +202,7 @@ Shader "Custom/Parallax"
                 GET_VERTEX_BIPLANAR_PARAMS(params, worldUVs, o.worldNormal);
 
                 // Do advanced blending
-                float4 displacementTex = SampleBiplanarTextureLOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, o.worldNormal, texLevelBlend);
+                float4 displacementTex = SAMPLE_ZERO_FADE_TEXTURE_LOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, o.worldNormal, texLevelBlend);
                 CALCULATE_ADVANCED_BLENDING_FACTORS(landMask, displacementTex)
 
                 // Defines 'displacedWorldPos'
@@ -231,7 +239,7 @@ Shader "Custom/Parallax"
                 DECLARE_INFLUENCE_TEXTURE
                 DECLARE_INFLUENCE_VALUES
 
-                float4 globalDisplacement = SampleBiplanarTexture(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);
+                float4 globalDisplacement = SAMPLE_ZERO_FADE_TEXTURE(_DisplacementMap);
 
                 //
                 // Localised altitude based textures
@@ -295,6 +303,7 @@ Shader "Custom/Parallax"
             CGPROGRAM
         
             #pragma multi_compile_local PARALLAX_SINGLE_LOW PARALLAX_SINGLE_MID PARALLAX_SINGLE_HIGH PARALLAX_DOUBLE_LOWMID PARALLAX_DOUBLE_MIDHIGH PARALLAX_FULL
+            #pragma multi_compile_local _          PARALLAX_FADE_TEXTURES
             #pragma multi_compile_fog
             #pragma multi_compile_shadowcaster
 
@@ -380,7 +389,7 @@ Shader "Custom/Parallax"
                 GET_VERTEX_BIPLANAR_PARAMS(params, worldUVs, v.worldNormal);
                 
                 // Do advanced blending
-                float4 displacementTex = SampleBiplanarTextureLOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, v.worldNormal, texLevelBlend);
+                float4 displacementTex = SAMPLE_ZERO_FADE_TEXTURE_LOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, v.worldNormal, texLevelBlend);
                 CALCULATE_ADVANCED_BLENDING_FACTORS(landMask, displacementTex)
 
                 // Defines 'displacedWorldPos'
@@ -417,6 +426,7 @@ Shader "Custom/Parallax"
         
             #pragma multi_compile_local           PARALLAX_SINGLE_LOW PARALLAX_SINGLE_MID PARALLAX_SINGLE_HIGH PARALLAX_DOUBLE_LOWMID PARALLAX_DOUBLE_MIDHIGH PARALLAX_FULL
             #pragma multi_compile_local _         INFLUENCE_MAPPING
+            #pragma multi_compile_local _         PARALLAX_FADE_TEXTURES
             #pragma multi_compile_fog
             #pragma multi_compile_fwdadd_fullshadows
         
@@ -515,7 +525,7 @@ Shader "Custom/Parallax"
                 GET_VERTEX_BIPLANAR_PARAMS(params, worldUVs, v.worldNormal);
 
                 // Do advanced blending
-                float4 displacementTex = SampleBiplanarTextureLOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, v.worldNormal, texLevelBlend);
+                float4 displacementTex = SAMPLE_ZERO_FADE_TEXTURE_LOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, v.worldNormal, texLevelBlend);
                 CALCULATE_ADVANCED_BLENDING_FACTORS(landMask, displacementTex)
         
                 // Defines 'displacedWorldPos' 
@@ -553,7 +563,7 @@ Shader "Custom/Parallax"
                 DECLARE_INFLUENCE_TEXTURE
                 DECLARE_INFLUENCE_VALUES
 
-                float4 globalDisplacement = SampleBiplanarTexture(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);
+                float4 globalDisplacement = SAMPLE_ZERO_FADE_TEXTURE(_DisplacementMap);
 
                 //
                 // Localised altitude based textures
@@ -637,6 +647,7 @@ Shader "Custom/Parallax"
             #pragma multi_compile_local _          EMISSION
             #pragma multi_compile_local _          ADVANCED_BLENDING
             #pragma multi_compile_local _          AMBIENT_OCCLUSION
+            #pragma multi_compile_local _          PARALLAX_FADE_TEXTURES
             #pragma multi_compile_fog
             #pragma multi_compile _ UNITY_HDR_ON
 
@@ -733,7 +744,7 @@ Shader "Custom/Parallax"
                 GET_VERTEX_BIPLANAR_PARAMS(params, worldUVs, o.worldNormal);
 
                 // Do advanced blending
-                float4 displacementTex = SampleBiplanarTextureLOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, o.worldNormal, texLevelBlend);
+                float4 displacementTex = SAMPLE_ZERO_FADE_TEXTURE_LOD(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, o.worldNormal, texLevelBlend);
                 CALCULATE_ADVANCED_BLENDING_FACTORS(landMask, displacementTex)
 
                 // Defines 'displacedWorldPos'
@@ -770,7 +781,7 @@ Shader "Custom/Parallax"
                 DECLARE_INFLUENCE_TEXTURE
                 DECLARE_INFLUENCE_VALUES
 
-                float4 globalDisplacement = SampleBiplanarTexture(_DisplacementMap, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);
+                float4 globalDisplacement = SAMPLE_ZERO_FADE_TEXTURE(_DisplacementMap);
 
                 //
                 // Localised altitude based textures

--- a/Assets/Shaders/Terrain/ParallaxUtils.cginc
+++ b/Assets/Shaders/Terrain/ParallaxUtils.cginc
@@ -207,19 +207,31 @@ float GetDisplacementLerpFactor(float heightLerp, float displacement1, float dis
 // When using lighter shader variations these aren't included
 //
 
+#if defined (PARALLAX_FADE_TEXTURES)
+    #define SAMPLE_TERRAIN_TEXTURE(diffuseSampler) SampleBiplanarTextureWithFade(diffuseSampler, _MainTexFade, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend, floorLogDistance)
+    #define SAMPLE_TERRAIN_NORMAL(normalSampler) SampleBiplanarNormalWithFade(normalSampler, _BumpMapFade, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend, floorLogDistance)
+    #define SAMPLE_ZERO_FADE_TEXTURE(texSampler) SampleBiplanarTextureWithZeroFade(texSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend, floorLogDistance)
+    #define SAMPLE_ZERO_FADE_TEXTURE_LOD(texSampler, params, worldPos0, worldPos1, worldNormal, blend) SampleBiplanarTextureLODWithZeroFade(texSampler, params, worldPos0, worldPos1, worldNormal, blend, floorLogDistance)
+#else
+    #define SAMPLE_TERRAIN_TEXTURE(diffuseSampler) SampleBiplanarTexture(diffuseSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend)
+    #define SAMPLE_TERRAIN_NORMAL(normalSampler) SampleBiplanarNormal(normalSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend)
+    #define SAMPLE_ZERO_FADE_TEXTURE(texSampler) SampleBiplanarTexture(texSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend)
+    #define SAMPLE_ZERO_FADE_TEXTURE_LOD(texSampler, params, worldPos0, worldPos1, worldNormal, blend) SampleBiplanarTextureLOD(texSampler, params, worldPos0, worldPos1, worldNormal, blend)
+#endif
+
 #if defined (INFLUENCE_MAPPING)
     #define BIPLANAR_TEXTURE_SET(diffuseName, normalName, diffuseSampler, normalSampler)                                                                                                        \
-        fixed4 diffuseName = SampleBiplanarTexture(diffuseSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);                                                       \
-        NORMAL_FLOAT normalName = SampleBiplanarNormal(normalSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);                                                          \
+        fixed4 diffuseName = SAMPLE_TERRAIN_TEXTURE(diffuseSampler);                                                                                                                           \
+        NORMAL_FLOAT normalName = SAMPLE_TERRAIN_NORMAL(normalSampler);                                                                                                                        \
         float diffuseName##Lum = (diffuseName.r * 0.21f + diffuseName.g * 0.72f + diffuseName.b * 0.07f) + 0.5f;                                                                                \
         diffuseName.rgb = lerp(vertexColor * diffuseName##Lum, diffuseName.rgb, diffuseName##InfluenceValue);
 #else
     #define BIPLANAR_TEXTURE_SET(diffuseName, normalName, diffuseSampler, normalSampler)                                                                                                        \
-        fixed4 diffuseName = SampleBiplanarTexture(diffuseSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);                                                       \
-        NORMAL_FLOAT normalName = SampleBiplanarNormal(normalSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);
+        fixed4 diffuseName = SAMPLE_TERRAIN_TEXTURE(diffuseSampler);                                                                                                                           \
+        NORMAL_FLOAT normalName = SAMPLE_TERRAIN_NORMAL(normalSampler);
 #endif
 
-#define BIPLANAR_TEXTURE(texName, texSampler)   fixed4 texName = SampleBiplanarTexture(texSampler, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);
+#define BIPLANAR_TEXTURE(texName, texSampler)   fixed4 texName = SAMPLE_ZERO_FADE_TEXTURE(texSampler);
 
 #define UNUSED_TEXTURE_SET(diffuseName, normalName, diffuseSampler, normalSampler)  \
     fixed4 diffuseName = 0;                                                         \
@@ -265,7 +277,7 @@ float GetDisplacementLerpFactor(float heightLerp, float displacement1, float dis
 
 // Get global influence texture and values, otherwise declare nothing
 #if defined (INFLUENCE_MAPPING)
-    #define DECLARE_INFLUENCE_TEXTURE float4 globalInfluence = SampleBiplanarTexture(_InfluenceMap, params, worldUVsLevel0, worldUVsLevel1, i.worldNormal, texLevelBlend);
+    #define DECLARE_INFLUENCE_TEXTURE float4 globalInfluence = SAMPLE_ZERO_FADE_TEXTURE(_InfluenceMap);
     #define DECLARE_INFLUENCE_VALUES                                \
         float lowDiffuseInfluenceValue = globalInfluence.r;         \
         float midDiffuseInfluenceValue = globalInfluence.g;         \

--- a/Assets/Shaders/Terrain/ParallaxVariables.cginc
+++ b/Assets/Shaders/Terrain/ParallaxVariables.cginc
@@ -13,6 +13,9 @@ sampler2D _BumpMapHigh;
 sampler2D _MainTexSteep;
 sampler2D _BumpMapSteep;
 
+sampler2D _MainTexFade;
+sampler2D _BumpMapFade;
+
 sampler2D _DisplacementMap;
 sampler2D _InfluenceMap;
 
@@ -49,6 +52,7 @@ float2 _MainTex_ST;
 
 float _BiplanarBlendFactor;
 float _Tiling;
+float _FadeTextureStartLevel;
 
 float _DisplacementScale;
 float _DisplacementOffset;

--- a/Mod Source/Parallax/ConfigLoader.cs
+++ b/Mod Source/Parallax/ConfigLoader.cs
@@ -490,6 +490,52 @@ namespace Parallax
                 ConfigUtils.TryParse(body.planetName, propertyName, configValue, typeof(int), out object result);
                 body.terrainShaderProperties.shaderFloats[propertyName] = (int)result;
             }
+
+            ParseOptionalTerrainFadeProperties(body, bodyNode);
+        }
+
+        private static void ParseOptionalTerrainFadeProperties(ParallaxTerrainBody body, ConfigNode bodyNode)
+        {
+            string mainTexFade = bodyNode.GetValue("_MainTexFade");
+            string bumpMapFade = bodyNode.GetValue("_BumpMapFade");
+
+            if (mainTexFade == null && bumpMapFade == null)
+            {
+                return;
+            }
+
+            if (mainTexFade == null || bumpMapFade == null)
+            {
+                Debug.LogWarning("[Parallax] Terrain fade textures on " + body.planetName + " require both _MainTexFade and _BumpMapFade. Disabling fade textures for this body.");
+                return;
+            }
+
+            bool mainTexExists = TextureLoader.TextureExists(mainTexFade);
+            bool bumpMapExists = TextureLoader.TextureExists(bumpMapFade);
+
+            if (!mainTexExists)
+            {
+                ParallaxDebug.LogCritical("This texture file doesn't exist: " + mainTexFade + " for planet: " + body.planetName);
+            }
+            if (!bumpMapExists)
+            {
+                ParallaxDebug.LogCritical("This texture file doesn't exist: " + bumpMapFade + " for planet: " + body.planetName);
+            }
+            if (!mainTexExists || !bumpMapExists)
+            {
+                Debug.LogWarning("[Parallax] Disabling terrain fade textures for " + body.planetName + " because one or more fade textures could not be found.");
+                return;
+            }
+
+            body.terrainShaderProperties.shaderTextures["_MainTexFade"] = mainTexFade;
+            body.terrainShaderProperties.shaderTextures["_BumpMapFade"] = bumpMapFade;
+
+            string fadeStartLevel = bodyNode.GetValue("_FadeTextureStartLevel");
+            if (fadeStartLevel != null)
+            {
+                ConfigUtils.TryParse(body.planetName, "_FadeTextureStartLevel", fadeStartLevel, typeof(float), out object result);
+                body.terrainShaderProperties.shaderFloats["_FadeTextureStartLevel"] = (float)result;
+            }
         }
 
         // ConfigNode is "ParallaxScaledProperties"

--- a/Mod Source/Parallax/Tools/Common.cs
+++ b/Mod Source/Parallax/Tools/Common.cs
@@ -212,6 +212,10 @@ namespace Parallax
         {
             this.planetName = planetName;
         }
+        private bool HasFadeTextures()
+        {
+            return terrainShaderProperties.shaderTextures.ContainsKey("_MainTexFade") && terrainShaderProperties.shaderTextures.ContainsKey("_BumpMapFade");
+        }
         public ConfigNode ToConfigNode()
         {
             ConfigNode node = new ConfigNode("Body");
@@ -252,6 +256,10 @@ namespace Parallax
         {
             Material baseMaterial = new Material(AssetBundleLoader.parallaxTerrainShaders["Custom/Parallax"]);
             baseMaterial.EnableKeyword("INFLUENCE_MAPPING");
+            if (HasFadeTextures())
+            {
+                baseMaterial.EnableKeyword("PARALLAX_FADE_TEXTURES");
+            }
 
             foreach (KeyValuePair<string, float> floatValue in terrainShaderProperties.shaderFloats)
             {
@@ -543,7 +551,11 @@ namespace Parallax
         /// </summary>
         public void ReadTerrainShaderProperties()
         {
-            scaledMaterialParams.shaderProperties.Append(terrainBody.terrainShaderProperties);
+            ShaderProperties terrainProperties = terrainBody.terrainShaderProperties.Clone() as ShaderProperties;
+            terrainProperties.shaderTextures.Remove("_MainTexFade");
+            terrainProperties.shaderTextures.Remove("_BumpMapFade");
+            terrainProperties.shaderFloats.Remove("_FadeTextureStartLevel");
+            scaledMaterialParams.shaderProperties.Append(terrainProperties);
         }
         public void LoadInitial(string shader)
         {


### PR DESCRIPTION
Enable _MainTexFade and _BumpMapFade in terrain configs so distant biplanar zoom sampling uses detail-free textures with smooth transitions, without changing existing Low/Mid/High altitude blending.

Enable by auto-detect these 2 lines (_MainTexFade and _BumpMapFade ) in cfg file:
```
ParallaxTerrain
{
	Body
	{
		name = 
		emissive = false
		ShaderProperties
		{
			...
			_MainTexFade = RSSOrigin2/Patches/PluginData/BlankTerrainColorSnowyTerrain.dds
			_BumpMapFade = RSSOrigin2/Patches/PluginData/BlankTerrainNormal.dds
			_FadeTextureStartLevel = 3 (This line is optional, default is 1)
			...
		}
	}
}
```
It won't affect other existing functions. No bugs during testing

### In-game demonstration:

https://github.com/user-attachments/assets/faf86bbb-94e1-4f66-bd7a-e25567de28fd

https://github.com/user-attachments/assets/03e5bacb-df46-4896-ba16-a44c89e51e71

### In-game comparison:
**Without** optional PQS terrain fade feature:

https://github.com/user-attachments/assets/521a345d-3e3f-4aef-bf06-82a4b6efc44b

**With** optional PQS terrain fade feature:

https://github.com/user-attachments/assets/f298be66-21c2-4ce8-902d-19c0561410fd

### Comparison of the same altitude:
**Without** optional PQS terrain fade feature:
<img width="1773" height="998" alt="image" src="https://github.com/user-attachments/assets/e690681f-eaa9-4383-b0d8-6a86ae54e2aa" />
**With** optional PQS terrain fade feature:
<img width="1773" height="998" alt="image" src="https://github.com/user-attachments/assets/3f248cac-a8e0-41e5-af43-948bd0c2335a" />