### PR TITLE
Fix an issue with yellowish planet tints with custom skyboxes

### DIFF
--- a/Mod Source/Parallax/Scaled System/SkyboxControl.cs
+++ b/Mod Source/Parallax/Scaled System/SkyboxControl.cs
@@ -194,7 +194,7 @@ namespace Parallax.Scaled_System
 
                 cubemap.Apply(false, true);
                 for (int i = 0; i < 6; i++)
-                    Graphics.CopyTexture(skyboxTextures[i], 0, cubemap, i);
+                    Graphics.CopyTexture(destTextures[i], 0, cubemap, i);
             }
             else
             {


### PR DESCRIPTION
The fallback path I added here was accidentally copying to the wrong texture, and this manifested as the skybox used by parallax being yellow. This only shows up when the skybox is overridden by an uncompressed texture, which is why it doesn't show up in stock.

This fixes the issue by copying to the correct texture.

Fixes #139